### PR TITLE
Feature | Dockerize app

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+DATABASE_HOST=multiexpopeople_db
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=password
+DATABASE_NAME=pultiexpopeople_development
+DATABASE_PORT=5432

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+DATABASE_HOST=multiexpopeople_db
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=password
+DATABASE_NAME=pultiexpopeople_test
+DATABASE_PORT=5432

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,41 @@
+# this file defines how to create image for app
+FROM ruby:2.7-alpine
+
+ENV APP_PATH /var/app
+ENV BUNDLE_VERSION 2.1.4
+ENV BUNDLE_PATH /usr/local/bundle/gems
+ENV TMP_PATH /tmp/
+ENV RAILS_LOG_TO_STDOUT true
+ENV RAILS_PORT 3000
+
+# copy entrypoint scripts and grant execution permissions
+COPY ./dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
+COPY ./test-docker-entrypoint.sh /usr/local/bin/test-entrypoint.sh
+RUN chmod +x /usr/local/bin/dev-entrypoint.sh && chmod +x /usr/local/bin/test-entrypoint.sh
+
+# install dependencies for application
+RUN apk -U add --no-cache \
+build-base \
+git \
+postgresql-dev \
+postgresql-client \
+libxml2-dev \
+libxslt-dev \
+nodejs \
+yarn \
+imagemagick \
+tzdata \
+less \
+&& rm -rf /var/cache/apk/* \
+&& mkdir -p $APP_PATH
+
+
+RUN gem install bundler --version "$BUNDLE_VERSION" \
+&& rm -rf $GEM_HOME/cache/*
+
+# navigate to app directory
+WORKDIR $APP_PATH
+
+EXPOSE $RAILS_PORT
+
+ENTRYPOINT [ "bundle", "exec" ]

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development, :test do
   gem 'rubocop-performance', '~> 1.13', '>= 1.13.2', require: false
   gem 'rubocop-rails', '~> 2.13', '>= 2.13.2', require: false
   gem 'rubocop-rspec', '~> 2.8', require: false
+  gem 'yaml-lint', '~> 0.0.10', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yaml-lint (0.0.10)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -493,6 +494,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (~> 4.2)
   webpacker (~> 5.0)
+  yaml-lint (~> 0.0.10)
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/dev-docker-entrypoint.sh
+++ b/dev-docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#make sure that this scrpit exis if here is an error
+set -e
+
+echo "Environment: $RAILS_ENV"
+
+# install missing gems if needed
+bundle check || bundle install --jobs 20 --retry 5
+
+# Remove pre-existing puma/passenger server.pid
+rm -f $APP_PATH/tmp/pids/server.pid
+
+# run passed commands prepanding 'bundle exec'
+bundle exec ${@}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3'
+networks:
+  development:
+  test:
+volumes:
+  db_data:
+  gem_cache:
+  shared_data:
+services:
+  multiexpopeople_db:
+    image: postgres:12.5-alpine
+    container_name: multiexpopeople_db
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - shared_data:/var/shared
+    networks:
+      - development
+      - test
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - 5099:5432
+  multiexpopeople_app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: multiexpopeople_app
+    volumes:
+      - .:/var/app
+      - shared_data:/var/shared
+      - gem_cache:/usr/local/bundle/gems
+    networks:
+      - development
+    ports:
+      - 3000:3000
+    stdin_open: true
+    tty: true
+    env_file: .env.development
+    entrypoint: dev-entrypoint.sh
+    command: ['rails', 'server', '-p', '3000', '-b', '0.0.0.0']
+    environment:
+      RAILS_ENV: development
+    depends_on:
+      - multiexpopeople_db
+  multiexpopeople_test:
+    image: multiexpopeople_multiexpopeople_app
+    container_name: multiexpopeople_test
+    volumes:
+      - .:/var/app
+      - shared_data:/var/shared
+      - gem_cache:/usr/local/bundle/gems
+    networks:
+      - test
+    ports:
+      - 3001:3000
+    stdin_open: true
+    tty: true
+    env_file: .env.test
+    entrypoint: test-entrypoint.sh
+    command: ["rails", "-v"]
+    environment:
+      RAILS_ENV: test
+    depends_on:
+      - multiexpopeople_db

--- a/test-docker-entrypoint.sh
+++ b/test-docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#make sure that this scrpit exis if here is an error
+set -e
+
+echo "Environment: $RAILS_ENV"
+
+# Check if we need to install new gems
+bundle check || bundle install --jobs 20 --retry 5
+
+# run passed commands prepanding 'bundle exec'
+bundle exec ${@


### PR DESCRIPTION
#### docker-compose build command logs
multiexpopeople_db uses an image, skipping
Building multiexpopeople_app
Step 1/15 : FROM ruby:2.7-alpine
2.7-alpine: Pulling from library/ruby
3d2430473443: Pull complete
78c8acccb3ef: Pull complete
08aefcf7c3b7: Pull complete
0aa6e5733779: Pull complete
3b292bf0cef7: Pull complete
Digest: sha256:bd211c7b64ded4d22cf6fd91bf13264ede1c503213edbf73901cbbc870ff37e6
Status: Downloaded newer image for ruby:2.7-alpine
 ---> a9e2a1d211ad
Step 2/15 : ENV APP_PATH /var/app
 ---> Running in 5dfc6d23c7f1
Removing intermediate container 5dfc6d23c7f1
 ---> 3d5b7c0b7a18
Step 3/15 : ENV BUNDLE_VERSION 2.1.4
 ---> Running in 38a48fb9da1b
Removing intermediate container 38a48fb9da1b
 ---> 8afbfe1ea361
Step 4/15 : ENV BUNDLE_PATH /usr/local/bundle/gems
 ---> Running in 34d5c4217a5a
Removing intermediate container 34d5c4217a5a
 ---> 20e31fcd73ab
Step 5/15 : ENV TMP_PATH /tmp/
 ---> Running in 2b2307d73186
Removing intermediate container 2b2307d73186
 ---> 6270fac4adb6
Step 6/15 : ENV RAILS_LOG_TO_STDOUT true
 ---> Running in a0233ba1c626
Removing intermediate container a0233ba1c626
 ---> 9f046ec85be0
Step 7/15 : ENV RAILS_PORT 3000
 ---> Running in f295166657ea
Removing intermediate container f295166657ea
 ---> ed8b32418229
Step 8/15 : COPY ./dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
 ---> 1d8ff81980fb
Step 9/15 : COPY ./test-docker-entrypoint.sh /usr/local/bin/test-entrypoint.sh
 ---> 326b50137309
Step 10/15 : RUN chmod +x /usr/local/bin/dev-entrypoint.sh && chmod +x /usr/local/bin/test-entrypoint.sh
 ---> Running in cdcb19de984a
Removing intermediate container cdcb19de984a
 ---> 2866603667e1
Step 11/15 : RUN apk -U add --no-cache build-base git postgresql-dev postgresql-client libxml2-dev libxslt-dev nodejs yarn imagemagick tzdata less && rm -rf /var/cache/apk/* && mkdir -p $APP_PATH
 ---> Running in f5cb39b99ac0
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/101) Installing binutils (2.37-r3)
(2/101) Installing libmagic (5.41-r0)
(3/101) Installing file (5.41-r0)
(4/101) Installing libgomp (10.3.1_git20211027-r0)
(5/101) Installing libatomic (10.3.1_git20211027-r0)
(6/101) Installing libgphobos (10.3.1_git20211027-r0)
(7/101) Installing isl22 (0.22-r0)
(8/101) Installing mpfr4 (4.1.0-r0)
(9/101) Installing mpc1 (1.2.1-r0)
(10/101) Installing gcc (10.3.1_git20211027-r0)
(11/101) Installing musl-dev (1.2.2-r7)
(12/101) Installing libc-dev (0.7.2-r3)
(13/101) Installing g++ (10.3.1_git20211027-r0)
(14/101) Installing make (4.3-r0)
(15/101) Installing fortify-headers (1.1-r1)
(16/101) Installing patch (2.7.6-r7)
(17/101) Installing build-base (0.5-r2)
(18/101) Installing brotli-libs (1.0.9-r5)
(19/101) Installing nghttp2-libs (1.46.0-r0)
(20/101) Installing libcurl (7.80.0-r0)
(21/101) Installing expat (2.4.7-r0)
(22/101) Installing pcre2 (10.39-r0)
(23/101) Installing git (2.34.1-r0)
(24/101) Installing libxau (1.0.9-r0)
(25/101) Installing libmd (1.0.3-r0)
(26/101) Installing libbsd (0.11.3-r1)
(27/101) Installing libxdmcp (1.1.3-r0)
(28/101) Installing libxcb (1.14-r2)
(29/101) Installing libx11 (1.7.2-r0)
(30/101) Installing libxext (1.3.4-r0)
(31/101) Installing libbz2 (1.0.8-r1)
(32/101) Installing libpng (1.6.37-r1)
(33/101) Installing freetype (2.11.0-r0)
(34/101) Installing libuuid (2.37.4-r0)
(35/101) Installing fontconfig (2.13.1-r4)
(36/101) Installing lcms2 (2.12-r1)
(37/101) Installing libltdl (2.4.6-r7)
(38/101) Installing xz-libs (5.2.5-r0)
(39/101) Installing libxml2 (2.9.13-r0)
(40/101) Installing imagemagick-libs (7.1.0.16-r0)
(41/101) Installing libxrender (0.9.10-r3)
(42/101) Installing pixman (0.40.0-r3)
(43/101) Installing cairo (1.16.0-r3)
(44/101) Installing libblkid (2.37.4-r0)
(45/101) Installing libmount (2.37.4-r0)
(46/101) Installing pcre (8.45-r1)
(47/101) Installing glib (2.70.1-r0)
(48/101) Installing dbus-libs (1.12.20-r4)
(49/101) Installing avahi-libs (0.8-r5)
(50/101) Installing nettle (3.7.3-r0)
(51/101) Installing p11-kit (0.24.0-r1)
(52/101) Installing libtasn1 (4.18.0-r0)
(53/101) Installing libunistring (0.9.10-r1)
(54/101) Installing gnutls (3.7.1-r0)
(55/101) Installing cups-libs (2.3.3-r5)
(56/101) Installing jbig2dec (0.19-r0)
(57/101) Installing libjpeg-turbo (2.1.2-r0)
(58/101) Installing libwebp (1.2.2-r0)
(59/101) Installing zstd-libs (1.5.0-r0)
(60/101) Installing tiff (4.3.0-r0)
(61/101) Installing ghostscript (9.55.0-r0)
(62/101) Installing aom-libs (3.2.0-r0)
(63/101) Installing libde265 (1.0.8-r1)
(64/101) Installing x265-libs (3.5-r0)
(65/101) Installing libheif (1.12.0-r2)
(66/101) Installing cairo-gobject (1.16.0-r3)
(67/101) Installing shared-mime-info (2.1-r0)
(68/101) Installing gdk-pixbuf (2.42.6-r0)
(69/101) Installing libxft (2.3.4-r0)
(70/101) Installing fribidi (1.0.11-r0)
(71/101) Installing graphite2 (1.3.14-r0)
(72/101) Installing harfbuzz (3.0.0-r2)
(73/101) Installing pango (1.48.10-r0)
(74/101) Installing librsvg (2.50.7-r1)
(75/101) Installing imagemagick (7.1.0.16-r0)
(76/101) Installing less (590-r0)
(77/101) Installing xz-dev (5.2.5-r0)
(78/101) Installing libxml2-dev (2.9.13-r0)
(79/101) Installing libgpg-error (1.42-r1)
(80/101) Installing libgcrypt (1.9.4-r0)
(81/101) Installing libxslt (1.1.35-r0)
(82/101) Installing libxslt-dev (1.1.35-r0)
(83/101) Installing c-ares (1.18.1-r0)
(84/101) Installing nodejs (16.14.0-r0)
(85/101) Installing postgresql-common (1.0-r0)
Executing postgresql-common-1.0-r0.pre-install
(86/101) Installing libpq (14.2-r0)
(87/101) Installing postgresql14-client (14.2-r0)
(88/101) Installing openssl-dev (1.1.1n-r0)
(89/101) Installing libpq-dev (14.2-r0)
(90/101) Installing libecpg (14.2-r0)
(91/101) Installing libecpg-dev (14.2-r0)
(92/101) Installing llvm12-libs (12.0.1-r0)
(93/101) Installing clang-libs (12.0.1-r1)
(94/101) Installing clang (12.0.1-r1)
(95/101) Installing icu-libs (69.1-r1)
(96/101) Installing icu (69.1-r1)
(97/101) Installing icu-dev (69.1-r1)
(98/101) Installing llvm12 (12.0.1-r0)
(99/101) Installing postgresql14-dev (14.2-r0)
(100/101) Installing tzdata (2022a-r0)
(101/101) Installing yarn (1.22.17-r0)
Executing busybox-1.34.1-r4.trigger
Executing fontconfig-2.13.1-r4.trigger
Executing shared-mime-info-2.1-r0.trigger
Executing gdk-pixbuf-2.42.6-r0.trigger
Executing postgresql-common-1.0-r0.trigger
* Setting postgresql14 as the default version
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/community: No such file or directory
sh: out of range
OK: 715 MiB in 137 packages
Removing intermediate container f5cb39b99ac0
 ---> 84a53b180b76
Step 12/15 : RUN gem install bundler --version "$BUNDLE_VERSION" && rm -rf $GEM_HOME/cache/*
 ---> Running in 71a87a9d1162
Successfully installed bundler-2.1.4
1 gem installed
Removing intermediate container 71a87a9d1162
 ---> bedc4a095bb0
Step 13/15 : WORKDIR $APP_PATH
 ---> Running in 25cc123cd0f6
Removing intermediate container 25cc123cd0f6
 ---> 2226bbd69349
Step 14/15 : EXPOSE $RAILS_PORT
 ---> Running in 2f3f574031d3
Removing intermediate container 2f3f574031d3
 ---> 2faaba39cc8a
Step 15/15 : ENTRYPOINT [ "bundle", "exec" ]
 ---> Running in a60bb4af71b0
Removing intermediate container a60bb4af71b0
 ---> 2cd58fcf9bbe
Successfully built 2cd58fcf9bbe
Successfully tagged multiexpopeople_multiexpopeople_app:latest
multiexpopeople_test uses an image, skipping